### PR TITLE
fix(security): remove hardcoded UIDs for OpenShift compatibility

### DIFF
--- a/control-plane/values.yaml
+++ b/control-plane/values.yaml
@@ -44,11 +44,11 @@ ctrl:
   podLabels: {}
 
   # -- Pod security context
-  podSecurityContext:
-    runAsNonRoot: true
-    runAsUser: 1000
-    runAsGroup: 1000
-    fsGroup: 1000
+  podSecurityContext: {}
+    # runAsNonRoot: true
+    # runAsUser: 1000
+    # runAsGroup: 1000
+    # fsGroup: 1000
 
   # -- Container security context
   securityContext:

--- a/proxy/values.yaml
+++ b/proxy/values.yaml
@@ -42,11 +42,11 @@ podAnnotations: {}
 podLabels: {}
 
 # -- Pod security context
-podSecurityContext:
-  runAsNonRoot: true
-  runAsUser: 1000
-  runAsGroup: 1000
-  fsGroup: 1000
+podSecurityContext: {}
+  # runAsNonRoot: true
+  # runAsUser: 1000
+  # runAsGroup: 1000
+  # fsGroup: 1000
 
 # -- Container security context
 securityContext:

--- a/web-ui/values.yaml
+++ b/web-ui/values.yaml
@@ -42,11 +42,11 @@ podAnnotations: {}
 podLabels: {}
 
 # -- Pod security context
-podSecurityContext:
-  runAsNonRoot: true
-  runAsUser: 1000
-  runAsGroup: 1000
-  fsGroup: 1000
+podSecurityContext: {}
+  # runAsNonRoot: true
+  # runAsUser: 1000
+  # runAsGroup: 1000
+  # fsGroup: 1000
 
 # -- Container security context
 securityContext:


### PR DESCRIPTION
Fixes #35

### Description
This PR addresses the OpenShift deployment issue caused by hardcoded UIDs in the `podSecurityContext`. 

By default, the `podSecurityContext` is now set to `{}` for all three charts (`control-plane`, `proxy`, and `web-ui`), allowing strict Kubernetes distributions like OpenShift to dynamically allocate UIDs via their restricted SCC. 

The previous default values (`runAsUser`, `runAsGroup`, and `fsGroup`) have been kept as comments in `values.yaml` for reference, making it easy for users to opt-in if needed.
